### PR TITLE
Use forked nrf5x-base.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "software/nrf5x-base"]
 	path = software/nrf5x-base
-	url = https://github.com/lab11/nrf5x-base.git
+	url = https://github.com/sloboste/nrf5x-base.git


### PR DESCRIPTION
We are now switching over to using forked versions of the nrf5x-base and nrf51-pure-gcc-setup so that we can modify that code.
